### PR TITLE
fix(svf-ex): fix a double free

### DIFF
--- a/src/svf-ex.cpp
+++ b/src/svf-ex.cpp
@@ -200,7 +200,6 @@ int main(int argc, char ** argv)
 
     // clean up memory
     delete vfg;
-    delete svfg;
     AndersenWaveDiff::releaseAndersenWaveDiff();
     SVFIR::releaseSVFIR();
 


### PR DESCRIPTION
`svf-ex.cpp` causes a segmentation fault due to double free.

The object `svfg` is explicitly deleted in `main()`, but the destructor of `SVFGBuilder` also deletes it.