### PR TITLE
modify PATH_SUFFIXS of Z3_LIBRARIES from "bin" to "lib"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
 else()
     find_library(Z3_LIBRARIES NAMES libz3.a libz3.so
             HINTS $ENV{Z3_DIR}
-            PATH_SUFFIXES bin)
+            PATH_SUFFIXES lib)
     find_path(Z3_INCLUDES NAMES z3++.h
             HINTS $ENV{Z3_DIR}
             PATH_SUFFIXES include z3)


### PR DESCRIPTION
libz3.a should be in the "${z3_prefix}/lib/" directory, Z3_LIBRARIES will not find target if it's "bin"