### PR TITLE
Sync to upstream SVF: LLVM 21.1.0, drop ubuntu-toolchain-r PPA

### DIFF
--- a/.github/workflows/svf-example-build.yml
+++ b/.github/workflows/svf-example-build.yml
@@ -33,10 +33,10 @@ jobs:
       - name: ubuntu-setup
         if: runner.os == 'Linux'
         run: |
+          # Avoid ppa:ubuntu-toolchain-r/test — Launchpad's PPA infrastructure
+          # has been intermittently unreachable from CI runners (HTTP 504 from
+          # add-apt-repository), and ubuntu-24.04's default gcc-13 is sufficient.
           sudo apt-get update
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
-          sudo apt-get install cmake gcc g++ nodejs doxygen graphviz
           sudo apt-get install -y build-essential cmake gcc g++ nodejs doxygen graphviz git curl software-properties-common lcov libncurses5-dev libtinfo6 libzstd-dev libffi-dev zlib1g-dev
 
       # install llvm and svf
@@ -48,7 +48,7 @@ jobs:
       - name: build-svf-example
         run: |
           export SVF_DIR=$(npm root)/SVF
-          export LLVM_DIR=$(npm root)/llvm-18.1.0.obj
+          export LLVM_DIR=$(npm root)/llvm-21.1.0.obj
           export Z3_DIR=$(npm root)/z3.obj
           cmake -B build -S ./ --install-prefix=$GITHUB_WORKSPACE/preinstall_svf
           cmake --build build --verbose

--- a/src/svf-example.cpp
+++ b/src/svf-example.cpp
@@ -31,6 +31,7 @@
 #include "SVF-LLVM/SVFIRBuilder.h"
 #include "Util/Options.h"
 #include "WPA/Andersen.h"
+#include "llvm/Support/ManagedStatic.h"
 
 using namespace llvm;
 using namespace std;


### PR DESCRIPTION
Match the upstream SVF/build.sh pin (MajorLLVMVer=21) and remove the ppa:ubuntu-toolchain-r/test add-apt-repository step.  Launchpad's PPA infrastructure has been intermittently unreachable from CI runners (HTTP 504 / 2-minute timeout from add-apt-repository), and ubuntu-24.04's default gcc-13 is sufficient for the SVF example build.